### PR TITLE
Added steemworlds-teleportsigns addon

### DIFF
--- a/STEEM.CRAFT/addons/steemworlds-teleportsigns.sk
+++ b/STEEM.CRAFT/addons/steemworlds-teleportsigns.sk
@@ -1,0 +1,79 @@
+#
+# ==============
+# steemworlds-teleportsigns.sk v0.0.1
+# ==============
+# steemworlds-teleportsigns.sk is part of the STEEM.CRAFT addons (addon to steemworlds.sk).
+# ==============
+# > steemworlds-teleportsigns allows players to create signs which
+# > send players to a specific steemworld by clicking on it.
+# ==============
+# > Usage:
+# > 1: [Steem]
+# > 2: Steem username
+# > 3: World name
+# > 4: empty
+# ==============
+
+#
+# > Modify these settings will also remove the teleport
+# > functionality from already existing teleport signs.
+options:
+  detectline: [Steem]
+  signhead: &l[Steem]
+  signfooter: &l>>Click here<<
+
+#
+# > Event - on sign change
+# > Triggered if a sign is placed and text has been saved.
+# > Actions:
+# > The username and permlink is going to be checked. If both are
+# > existing, it will be formatted and clickable.
+on sign change:
+  #
+  # > Only detect signs which match with the detectline option.
+  if line 1 is "{@detectline}":
+    #
+    # > Get line 2 and line 3 with lowercase characters.
+    set {_name} to (line 2).toLowerCase()
+    set {_worldname} to (line 3).toLowerCase()
+
+    #
+    # > If the given username is not set, tell the that the 2nd
+    # > line needs a steem username. Also break the sign again.
+    if getAccount({_name}) is not set:
+      message "%getChatPrefix()% Set a valid Steem name on the 2nd line."
+      event-block.breakNaturally()
+      stop
+
+    #
+    # > Create a permlink which can be used to get the world to check
+    # > if it actually exists.
+    set {_permlink} to "re-steemcraft-steemworlds-%{_name}%-%{_worldname}%"
+    set {_c} to getSteemContent({_name},{_permlink})
+	
+    #
+    # > If the author of the world is not set, it doesn't exist. Tell the
+    # > player that a valid world name on the 3rd line is necessary.
+	# > Also, break the sign naturally.
+    if {_c}.getAuthor().getName() is not set:
+      message "%getChatPrefix()% Set a valid world name on the 3rd line."
+      event-block.breakNaturally()
+      stop
+
+    #
+    # > Since this is executed, no errors have occured above, format the
+    # > sign to make it clickable.
+    set line 1 to "{@signhead}"
+    set line 4 to "{@signfooter}"
+
+#
+# > Event - on rightclick on sign
+# > Triggered if someone rightclicks on a sign.
+# > Actions:
+# > Calls the /steemworldvisit command for the player,
+# > which teleports the player to the world, if the
+# > sign has the right format.
+on rightclick on sign:
+  if line 1 of event-block is "{@signhead}":
+    if line 4 of event-block is "{@signfooter}":
+      make player execute "/steemworldvisit %line 2% %line 3%"


### PR DESCRIPTION
This addon allows players to visit different steemworlds using a sign. Useful to create a hub world with interesting places.

Working example: https://youtu.be/E6Xd9vBoJWM

- [x] Works as expected
- [x] Loads without errors