### PR TITLE
Use async threads to prevent lags on the server

### DIFF
--- a/STEEM.CRAFT/addons/steemworlds-teleportsigns.sk
+++ b/STEEM.CRAFT/addons/steemworlds-teleportsigns.sk
@@ -1,6 +1,6 @@
 #
 # ==============
-# steemworlds-teleportsigns.sk v0.0.2
+# steemworlds-teleportsigns.sk v0.0.3
 # ==============
 # steemworlds-teleportsigns.sk is part of the STEEM.CRAFT addons (addon to steemworlds.sk).
 # ==============
@@ -40,7 +40,19 @@ on sign change:
     #
     # > If the given username is not set, tell the that the 2nd
     # > line needs a steem username. Also break the sign again.
-    if getAccount({_name}) is not set:
+    # > Load the world comment.
+    getAccount({_name})
+
+    #
+    # > Wait until the Steem account response is no longer "wait".
+    while getAccountResponse({_name}) is "wait":
+      wait 1 tick
+
+    #
+    # > Get the Steem account response.
+    set {_account} to getAccountResponse({_name})
+
+    if {_account} is not set:
       message "%getChatPrefix()% Set a valid Steem name on the 2nd line."
       event-block.breakNaturally()
       stop

--- a/STEEM.CRAFT/addons/steemworlds-teleportsigns.sk
+++ b/STEEM.CRAFT/addons/steemworlds-teleportsigns.sk
@@ -1,6 +1,6 @@
 #
 # ==============
-# steemworlds-teleportsigns.sk v0.0.1
+# steemworlds-teleportsigns.sk v0.0.2
 # ==============
 # steemworlds-teleportsigns.sk is part of the STEEM.CRAFT addons (addon to steemworlds.sk).
 # ==============
@@ -49,8 +49,20 @@ on sign change:
     # > Create a permlink which can be used to get the world to check
     # > if it actually exists.
     set {_permlink} to "re-steemcraft-steemworlds-%{_name}%-%{_worldname}%"
-    set {_c} to getSteemContent({_name},{_permlink})
-	
+
+    #
+    # > Load the world comment.
+    getSteemContent({_name},{_permlink})
+
+    #
+    # > Wait until the Steem content response is no longer "wait".
+    while getSteemContentResponse({_name},{_permlink}) is "wait":
+      wait 1 tick
+
+    #
+    # > Get the Steem content response.
+    set {_c} to getSteemContentResponse({_name},{_permlink})
+
     #
     # > If the author of the world is not set, it doesn't exist. Tell the
     # > player that a valid world name on the 3rd line is necessary.

--- a/STEEM.CRAFT/addons/steemworlds.sk
+++ b/STEEM.CRAFT/addons/steemworlds.sk
@@ -171,14 +171,32 @@ command /visit [<text>] [<text=home>]:
     set {_worldname} to normalize({_worldname})
 
     #
+    # > Check if the account exists.
+    getAccount({_steemaccount})
+
+    #
+    # > Wait for a response which happens in a thread.
+    while getAccountResponse({_steemaccount}) is "wait":
+      wait 1 tick
+
+    #
     # > To also support entering the ingame username, this part will
     # > convert the ingame username to the steem account name.
-    if getAccount({_steemaccount}) is not set:
+    if getAccountResponse({_steemaccount}) is not set:
       set {_steemaccount} to getSyncedAccount({_steemaccount} parsed as offline player)
+      #
+      # > Check this again for existance.
+      getAccount({_steemaccount})
+	
+      #
+      # > Wait again for the response.
+      while getAccountResponse({_steemaccount}) is "wait":
+        wait 1 tick
 
     #
     # > Only create a world, if the steem account exists.
-    if getAccount({_steemaccount}) is set:
+    if getAccountResponse({_steemaccount}) is set:
+
       #
       # > Check if the world exists on Steem.
       getSteemContent({_steemaccount},{_permlink})

--- a/STEEM.CRAFT/addons/steemworlds.sk
+++ b/STEEM.CRAFT/addons/steemworlds.sk
@@ -1,6 +1,6 @@
 #
 # ==============
-# steemworlds.sk v0.0.7
+# steemworlds.sk v0.0.8
 # ==============
 # steemworlds.sk is part of the STEEM.CRAFT addons.
 # ==============
@@ -181,7 +181,17 @@ command /visit [<text>] [<text=home>]:
     if getAccount({_steemaccount}) is set:
       #
       # > Check if the world exists on Steem.
-      set {_c} to getSteemContent({_steemaccount},{_worldname})
+      getSteemContent({_steemaccount},{_permlink})
+
+      #
+      # > Wait until the Steem content response is no longer "wait".
+      while getSteemContentResponse({_steemaccount},{_permlink}) is "wait":
+        wait 1 tick
+
+      #
+      # > Get the Steem content response.
+      set {_c} to getSteemContentResponse({_steemaccount},{_permlink})
+
       set {_world} to "%{_steemaccount}%-%{_worldname}%"
       set {_author} to {_c}.getAuthor().getName().toString()
 
@@ -559,8 +569,17 @@ function loadSteemWorld(steemname:text,worldname:text,player:player):
     {_bossbar}.setVisible(true)
 
     #
-    # > Loading the content. There is no verification.
-    set {_c} to getSteemContent({_steemname},{_permlink})
+    # > Load the content.
+    getSteemContent({_steemname},{_permlink})
+
+    #
+    # > Wait until the Steem content response is no longer "wait".
+    while getSteemContentResponse({_steemname},{_permlink}) is "wait":
+      wait 1 tick
+
+    #
+    # > Get the Steem content response.
+    set {_c} to getSteemContentResponse({_steemname},{_permlink})
 
     #
     # > Reading the json metadata of the content is done using ObjectMapper.

--- a/STEEM.CRAFT/addons/steemworlds.sk
+++ b/STEEM.CRAFT/addons/steemworlds.sk
@@ -358,8 +358,14 @@ function saveSteemWorld(player:player):
       set {_file} to new File("tmp/steemworlds_%{_world}%_%loop-value.getX()%_%loop-value.getZ()%.schem")
       set {_chunkx} to loop-value.getX()
       set {_chunkz} to loop-value.getZ()
-      set {_b} to BlockVector3.at({_x1}, 0, {_z1})
-      set {_t} to BlockVector3.at({_x2}, 255, {_z2})
+
+      #
+      # > WorldEdit is maybe unsure how it should place the blocks if it is
+      # > exactly on 0.5, that's why 0.5 is deducted on x- and z-coords.
+      # > This is also done in the loading process to match this.
+      set {_b} to BlockVector3.at({_x1}-0.5, 0, {_z1}-0.5)
+      set {_t} to BlockVector3.at({_x2}-0.5, 255, {_z2}-0.5)
+
       set {_bworld} to new BukkitWorld({_world})
       set {_reg} to new CuboidRegion({_bworld}, {_b}, {_t})
       set {_schem} to new Schematic({_reg})

--- a/STEEM.CRAFT/addons/steemworlds.sk
+++ b/STEEM.CRAFT/addons/steemworlds.sk
@@ -59,7 +59,7 @@ options:
   #
   # > The commennt parent permlink works the same way the parent author works.
   # > If this is changed, you can't load worlds from other comment parent permlinks.
-  commentparentpermlink: steemcraft11052019065000
+  commentparentpermlink: w
 
 import:
   java.io.File
@@ -569,13 +569,12 @@ function loadSteemWorld(steemname:text,worldname:text,player:player):
     {_bossbar}.setVisible(true)
 
     #
-    # > Load the content.
-    getSteemContent({_steemname},{_permlink})
-
-    #
-    # > Wait until the Steem content response is no longer "wait".
-    while getSteemContentResponse({_steemname},{_permlink}) is "wait":
+    # > Load the content using getSteemContentAsync without thread,
+    # > since we're already in a thread.
+    while metadata value "SteemContentRequest" of getDummy() is set:
       wait 1 tick
+    set metadata value "SteemContentRequest" of getDummy() to [{_steemname},{_permlink}]
+    getSteemContentAsync(metadata value "SteemContentRequest" of getDummy())
 
     #
     # > Get the Steem content response.
@@ -628,7 +627,11 @@ function loadSteemWorld(steemname:text,worldname:text,player:player):
     # > informations.
     loop {_plotparts::*}:
       add 1 to {_partnumber}
+
+      #
+      # > Get the operations of a block.
       set {_ops} to getOpsInBlock(loop-value,false)
+
       loop {_ops}.size() times:
         set {_tx} to loop-number - 1
         #

--- a/STEEM.CRAFT/addons/steemworlds.sk
+++ b/STEEM.CRAFT/addons/steemworlds.sk
@@ -261,11 +261,27 @@ function saveSteemWorld(player:player):
       message "%getChatPrefix()% You have to sync your account first:" to {_player}
       message "%getChatPrefix()% /steemconnect <steem username>" to {_player}
       stop
-    if validateSyncedSteemAccountUUID({_player}) is false:
+    
+    #
+    # > Get the account in a thread to validate.
+    getAccount("%{_steemname}%")
+	
+    #
+    # > Wait until the response is ready.
+    while getAccountResponse("%{_steemname}%") is "wait":
+      wait 1 tick
+
+    #
+    # > Set the response to a local usable variable.
+    set {_account} to getAccountResponse("%{_steemname}%")
+
+    #
+    # > Check if the account is valid and usable for broadcasting.
+    if validateSyncedSteemAccountUUID({_player},{_account}) is false:
       message "%getChatPrefix()% Your Steem account UUID doesn't match with yours." to {_player}
       message "%getChatPrefix()% /steemconnect <steem username>" to {_player}
       stop
-    if validateSyncedSteemAccountAuths({_player}) is false:
+    if validateSyncedSteemAccountAuths({_player},{_account}) is false:
       message "%getChatPrefix()% The server has no authorisation to broadcast transactions for you." to {_player}
       message "%getChatPrefix()% /steemconnect <steem username>" to {_player}
       stop
@@ -720,7 +736,11 @@ function loadSteemWorld(steemname:text,worldname:text,player:player):
       set {_l} to location of {_block}
       set {_x} to x-coord of {_l}
       set {_z} to z-coord of {_l}
-      set {_vector} to BlockVector3.at({_x}, 0, {_z})
+
+      #
+      # > Deduct 0.5 from each vector to prevent incorrect rounding within
+      # > WorldEdit which can corrupt worlds.
+      set {_vector} to BlockVector3.at({_x}-0.5, 0, {_z}-0.5)
 
       #
       # > WorldEdit needs a BukkitWorld instead of a CraftWorld to work.

--- a/STEEM.CRAFT/core/functions/createComment.sk
+++ b/STEEM.CRAFT/core/functions/createComment.sk
@@ -238,12 +238,14 @@ function asyncCreateComment(tx:object):
   # > Get the Steem content to geht the maybe already existing beneficaries.
   set {_accountname} to {_account}.getName().toString()
   set {_perlinkstring} to {_permlink}.getLink().toString()
-  getSteemContent({_accountname},{_perlinkstring})
 
   #
-  # > Wait until the Steem content response is no longer "wait".
-  while getSteemContentResponse({_accountname},{_perlinkstring}) is "wait":
+  # > Load the content using getSteemContentAsync without thread,
+  # > since we're already in a thread.
+  while metadata value "SteemContentRequest" of getDummy() is set:
     wait 1 tick
+  set metadata value "SteemContentRequest" of getDummy() to [{_accountname},{_perlinkstring}]
+  getSteemContentAsync(metadata value "SteemContentRequest" of getDummy())
 
   #
   # > Get the Steem content response.

--- a/STEEM.CRAFT/core/functions/createComment.sk
+++ b/STEEM.CRAFT/core/functions/createComment.sk
@@ -236,7 +236,18 @@ function asyncCreateComment(tx:object):
 
   #
   # > Get the Steem content to geht the maybe already existing beneficaries.
-  set {_content} to getSteemContent({_account}.getName().toString(),{_permlink}.getLink().toString())
+  set {_accountname} to {_account}.getName().toString()
+  set {_perlinkstring} to {_permlink}.getLink().toString()
+  getSteemContent({_accountname},{_perlinkstring})
+
+  #
+  # > Wait until the Steem content response is no longer "wait".
+  while getSteemContentResponse({_accountname},{_perlinkstring}) is "wait":
+    wait 1 tick
+
+  #
+  # > Get the Steem content response.
+  set {_content} to getSteemContentResponse({_accountname},{_perlinkstring})
 
   #
   # > Only do add CommentOptions if there is no comment for this author and permlink yet.

--- a/STEEM.CRAFT/core/functions/getAccount.sk
+++ b/STEEM.CRAFT/core/functions/getAccount.sk
@@ -12,13 +12,64 @@ import:
 
 #
 # > Function - getAccount
-# > Returns a steem wallet account
+# > Calls getAccountAsync in a thread.
 # > Parameters:
 # > <text>a steem wallet account name
-function getAccount(account:text) :: object:
-  set {_steemj} to new SteemJ()
+function getAccount(account:text):
+  set metadata value "Account-%{_account}%" of getDummy() to "wait"
+
+  #
+  # > Convert the username to a valid format to prevent errors.
   set {_account} to {_account}.toLowerCase()
   set {_account} to new AccountName({_account})
+  
+  #
+  # > The account is needed to be passed within a ArrayList, sice it supports
+  # > getting multiple accounts. Because we only need one, only add one account.
   set {_accountrequest} to new ArrayList()
   {_accountrequest}.add({_account})
-  return {_steemj}.getAccounts({_accountrequest}).get(0)
+
+  #
+  # > Only create one account request at a time.
+  while metadata value "AccountRequest" of getDummy() is set:
+    wait 1 tick
+  set metadata value "AccountRequest" of getDummy() to {_accountrequest}
+
+  #
+  # > Call the getAccountAsync function in a thread to prevent slowing down
+  # > the server.
+  $ thread
+  getAccountAsync(metadata value "AccountRequest" of getDummy())
+
+#
+# > Function - getAccountAsync
+# > Tries to get the requested account and set it as metadata for 5 seconds.
+# > Parameters:
+# > <ArrayList>a arraylist containing the requested AccountName.
+function getAccountAsync(accountrequest:object):
+  #
+  # > Delete the AccountRequest metadata value instantly to allow
+  # > more of these calls to happen.
+  delete metadata value "AccountRequest" of getDummy()
+
+  set {_steemj} to new SteemJ()
+  
+  #
+  # > Save the result as a metadata value for 5 seconds to allow functions
+  # > which are waiting for it to access it.
+  set {_result} to {_steemj}.getAccounts({_accountrequest}).get(0)
+  set metadata value "Account-%{_accountrequest}.get(0).getName()%" of getDummy() to {_result}
+
+  #
+  # > Delete the saved account again, to keep the storage clean.
+  wait 5 seconds
+  delete metadata value "Account-%{_accountrequest}.get(0).getName()%" of getDummy()
+
+#
+# > Function - getAccountResponse
+# > Returns the last response from getAccount.
+# > Parameters:
+# > <text>a steem wallet account name
+function getAccountResponse(account:text) :: object:
+  set {_account} to {_account}.toLowerCase()
+  return metadata value "Account-%{_account}%" of getDummy()

--- a/STEEM.CRAFT/core/functions/getSteemContent.sk
+++ b/STEEM.CRAFT/core/functions/getSteemContent.sk
@@ -12,10 +12,48 @@ import:
 
 #
 # > Function - getSteemContent:
-# > Returns the content of the specified author and permlink.
+# > Calls the getSteemContentAsync function in a thread.
 # > Parameters:
 # > <text>author
 # > <text>permlink
-function getSteemContent(author:text,permlink:text) :: object:
+function getSteemContent(author:text,permlink:text):
+  set metadata value "SteemContent-%{_author}%-%{_permlink}%" of getDummy() to "wait"
+  #
+  # > Only create one steem content request at a time, wait until the prevous
+  # > one is done, this may take some milliseconds.
+  while metadata value "SteemContentRequest" of getDummy() is set:
+    wait 1 tick
+  set metadata value "SteemContentRequest" of getDummy() to [{_author},{_permlink}]
+  #
+  # > Run the task in a thread, since it will halt the server.
+  $ thread
+  getSteemContentAsync(metadata value "SteemContentRequest" of getDummy())
+
+#
+# > Function - getSteemContentAsync:
+# > Sets the content of the specified author and permlink as metadata value.
+# > Parameters:
+# > <Array>[author,permlink]
+function getSteemContentAsync(array:object):
+  delete metadata value "SteemContentRequest" of getDummy()
+  #
+  # > Convert the array to a Skript list.
+  set {_array::*} to ...{_array}
   set {_steemj} to new SteemJ()
-  return {_steemj}.getContent(new AccountName({_author}),new Permlink({_permlink}))
+  #
+  # > Get the content, the strings have to be converted to AccountName and Permlink.
+  set {_result} to {_steemj}.getContent(new AccountName({_array::1}),new Permlink({_array::2}))
+  set metadata value "SteemContent-%{_array::1}%-%{_array::2}%" of getDummy() to {_result}
+  #
+  # > After 5 seconds, delete the response to keep the server clean.
+  wait 5 seconds
+  delete metadata value "SteemContent-%{_array::1}%-%{_array::2}%" of getDummy()
+
+#
+# > Function - getSteemContentResponse:
+# > Returns the current response avaiable for a previous content call.
+# > Parameters:
+# > <text>author
+# > <text>permlink
+function getSteemContentResponse(author:text,permlink:text) :: object:
+  return metadata value "SteemContent-%{_author}%-%{_permlink}%" of getDummy()

--- a/STEEM.CRAFT/core/functions/getSteemContent.sk
+++ b/STEEM.CRAFT/core/functions/getSteemContent.sk
@@ -18,12 +18,14 @@ import:
 # > <text>permlink
 function getSteemContent(author:text,permlink:text):
   set metadata value "SteemContent-%{_author}%-%{_permlink}%" of getDummy() to "wait"
+
   #
   # > Only create one steem content request at a time, wait until the prevous
   # > one is done, this may take some milliseconds.
   while metadata value "SteemContentRequest" of getDummy() is set:
     wait 1 tick
   set metadata value "SteemContentRequest" of getDummy() to [{_author},{_permlink}]
+
   #
   # > Run the task in a thread, since it will halt the server.
   $ thread
@@ -36,14 +38,17 @@ function getSteemContent(author:text,permlink:text):
 # > <Array>[author,permlink]
 function getSteemContentAsync(array:object):
   delete metadata value "SteemContentRequest" of getDummy()
+
   #
   # > Convert the array to a Skript list.
   set {_array::*} to ...{_array}
   set {_steemj} to new SteemJ()
+
   #
   # > Get the content, the strings have to be converted to AccountName and Permlink.
   set {_result} to {_steemj}.getContent(new AccountName({_array::1}),new Permlink({_array::2}))
   set metadata value "SteemContent-%{_array::1}%-%{_array::2}%" of getDummy() to {_result}
+
   #
   # > After 5 seconds, delete the response to keep the server clean.
   wait 5 seconds

--- a/STEEM.CRAFT/core/functions/validation/validateSyncedSteemAccountAuths.sk
+++ b/STEEM.CRAFT/core/functions/validation/validateSyncedSteemAccountAuths.sk
@@ -11,28 +11,16 @@
 # > false is returned.
 # > Parameters:
 # > <offline player>the player which should be checked for being synced
-# > <text>the steem account which should be checked for being synced
+# > <SteemJ account>a SteemJ account object
 # > Returns:
 # > <boolean>true=synced | false=not synced
-function validateSyncedSteemAccountAuths(player:offline player, account:text="checkstorage") :: boolean:
+function validateSyncedSteemAccountAuths(player:offline player, account:object) :: boolean:
   #
-  # > If there has been no account defined, use already synced one to
-  # > validate.
-  if {_account} is "checkstorage":
-    set {_account} to getSyncedAccount({_player})
-    #
-    # > If there is no account defined in the parameters and not stored
-    # > on the server, return false.
-    if {_account} is false:
-      return false
-
-  #
-  # > Since there is an account stored, get the account from the
-  # > Steem Blockchain to check if the server has the needed auths.
+  # > Check if the given steem account authorized the server Steem account.
   set {_accountdata} to getAccount({_account})
-  if {_accountdata} is set:
+  if {_account} is set:
     set {_neededauth} to getServerAccountName()
-    loop ...{_accountdata}.getPosting().getAccountAuths().keySet():
+    loop ...{_account}.getPosting().getAccountAuths().keySet():
       if "%loop-value%" is {_neededauth}:
         return true
     return false

--- a/STEEM.CRAFT/core/functions/validation/validateSyncedSteemAccountAuths.sk
+++ b/STEEM.CRAFT/core/functions/validation/validateSyncedSteemAccountAuths.sk
@@ -17,7 +17,6 @@
 function validateSyncedSteemAccountAuths(player:offline player, account:object) :: boolean:
   #
   # > Check if the given steem account authorized the server Steem account.
-  set {_accountdata} to getAccount({_account})
   if {_account} is set:
     set {_neededauth} to getServerAccountName()
     loop ...{_account}.getPosting().getAccountAuths().keySet():

--- a/STEEM.CRAFT/core/functions/validation/validateSyncedSteemAccountUUID.sk
+++ b/STEEM.CRAFT/core/functions/validation/validateSyncedSteemAccountUUID.sk
@@ -14,7 +14,7 @@ import:
 # > false is returned.
 # > Parameters:
 # > <offline player>the player which should be checked for being synced
-# > <SteeJ account>a SteemJ account object
+# > <SteemJ account>a SteemJ account object
 # > Returns:
 # > <boolean>true=synced | false=not synced
 function validateSyncedSteemAccountUUID(player:offline player, account:object) :: boolean:

--- a/STEEM.CRAFT/core/functions/validation/validateSyncedSteemAccountUUID.sk
+++ b/STEEM.CRAFT/core/functions/validation/validateSyncedSteemAccountUUID.sk
@@ -14,27 +14,14 @@ import:
 # > false is returned.
 # > Parameters:
 # > <offline player>the player which should be checked for being synced
-# > <text>the steem account which should be checked for being synced
+# > <SteeJ account>a SteemJ account object
 # > Returns:
 # > <boolean>true=synced | false=not synced
-function validateSyncedSteemAccountUUID(player:offline player, account:text="checkstorage") :: boolean:
+function validateSyncedSteemAccountUUID(player:offline player, account:object) :: boolean:
   #
-  # > If there has been no account defined, use already synced one to
-  # > validate.
-  if {_account} is "checkstorage":
-    set {_account} to getSyncedAccount({_player})
-    #
-    # > If there is no account defined in the parameters and not stored
-    # > on the server, return false.
-    if {_account} is false:
-      return false
-
-  #
-  # > Since there is an account stored, get the account from the
-  # > Steem Blockchain to check if the saved uuid matches with the player.
-  set {_accountdata} to getAccount({_account})
-  if {_accountdata} is set:
-    set {_json} to {_accountdata}.getJsonMetadata()
+  # > Check if the given steem account matches up with the given minecraft user.
+  if {_account} is set:
+    set {_json} to {_account}.getJsonMetadata()
     set {_objectMapper} to new ObjectMapper()
     set {_jsonNode} to {_objectMapper}.readTree({_json})
 


### PR DESCRIPTION
This pull request aims to change any non async requests to Steem to async. This will prevent the server from being slowed down once multiple players trying innteract with steem based worlds.

- [x] Works still as expected
- [x] Loads without errors

An error has been fixed which occured sometimes, the vector now is not on 0.5 block locations but on 0.0 locations. Here is a example between two versions, without fix first and then with fix: https://youtu.be/u-hNTD0wFX8