### PR TITLE
Added loadSteemWorldData function

### DIFF
--- a/STEEM.CRAFT/addons/steemworlds.sk
+++ b/STEEM.CRAFT/addons/steemworlds.sk
@@ -1,6 +1,6 @@
 #
 # ==============
-# steemworlds.sk v0.0.11
+# steemworlds.sk v0.0.12
 # ==============
 # steemworlds.sk is part of the STEEM.CRAFT addons.
 # ==============
@@ -82,6 +82,8 @@ import:
   com.sk89q.worldedit.EditSession
   com.sk89q.worldedit.world.World
   com.sk89q.worldedit.math.BlockVector3
+  java.util.HashMap
+  java.util.ArrayList
 
 #
 # > Command - /steemworldsize | /swsize, /scsize
@@ -638,10 +640,6 @@ function loadSteemWorld(steemname:text,worldname:text,player:player):
     replace "steemworlds-" with "" in {_shortworld}
 
     #
-	# > Set the permlink to allow getting the comment content.
-    set {_permlink} to "re-steemcraft-%{_worldname}%"
-
-    #
     # > Tell the player that the world is now being loaded.
     message "%getChatPrefix()% Loading %{_steemname}%'s world..." to {_player}
 
@@ -653,127 +651,28 @@ function loadSteemWorld(steemname:text,worldname:text,player:player):
     {_bossbar}.addPlayer({_player})
     {_bossbar}.setVisible(true)
 
+    # 
+    # > Load the world data using loadSteemWorldData. By adding the bossbar
+    # > variable, the player gets informed about the loading progress.
+    set {_map} to loadSteemWorldData({_steemname},{_worldname},{_bossbar})
 
     #
-    # > Load the content using getSteemContentAsync without thread,
-    # > since we're already in a thread.
-    set metadata value "SteemContentRequest" of getDummy() to [{_steemname},{_permlink}]
-
-    getSteemContentAsync(metadata value "SteemContentRequest" of getDummy())
-
-    while metadata value "SteemContentRequest" of getDummy() is set:
-      wait 1 tick
-
-    #
-    # > Get the Steem content response.
-    set {_c} to getSteemContentResponse({_steemname},{_permlink})
-
-    #
-    # > Reading the json metadata of the content is done using ObjectMapper.
-    set {_objectMapper} to new ObjectMapper()
-    set {_jsonNode} to {_objectMapper}.readTree({_c}.getJsonMetadata())
-
-    #
-    # > Get the compressed and base64 encoded string.
-    set {_plot} to {_jsonNode}.get("world").textValue()
-
-    #
-    # > Get the serialized location and save it to the storage.
-    set {_spawn} to {_jsonNode}.get("spawn").textValue()
-    saveGeneralStorageData("steemworlds",{_shortworld},"spawn",{_spawn})
-
-    #
-    # > Set the world size to the defined size in the Steem comment.
-    set {_size} to {_jsonNode}.get("wsize").doubleValue()
-    set {_size} to {_size}*32
-    set {_wb} to {_world}.getWorldBorder()
-    {_wb}.setWarningDistance(0)
-    {_wb}.setSize({_size})
-
-    #
-    # > Decompress and decode the base64 string, this increases the size.
-    set {_plot} to decompressBase64({_plot})
-
-    #
-    # > Since we now have a string, it has to be loaded using jackson again,
-    # > to access it later.
-    set {_plot} to {_objectMapper}.readTree({_plot})
-
-    #
-    # > Get all the block numers to load the chunks.
-    loop {_plot}.size().longValue() times:
-      set {_plotpart} to {_plot}.get(loop-number - 1)
-      set {_x} to {_plotpart}.get("x")
-      set {_z} to {_plotpart}.get("z")
-      set {_i} to {_plotpart}.get("i")
-      set {_b} to {_plotpart}.get("b").textValue()
-
-      set {_plotparts::%{_x}%|%{_z}%|%{_i}%} to {_b} parsed as number
-      add 1 to {_plotpartamount::%{_x}%|%{_z}%}
+    # > The returned HashMap contains the response and the world. We need the
+    # > world.
+    set {_worlddata} to {_map}.get("world")
 
     #
     # > Get the size of the plotparts to give the player a loading bar.
-    set {_plotsize} to size of {_plotparts::*}
+    set {_worlddataparts::*} to ...{_worlddata}.keySet()
+    set {_plotsize} to size of {_worlddataparts::*}
     set {_pdone} to 100 / {_plotsize}
 
-    #
-    # > Loop through the parts of the world and gather the needed
-    # > informations.
-    loop {_plotparts::*}:
-      add 1 to {_partnumber}
+    loop {_worlddataparts::*}:
 
-      #
-      # > Get the operations of a block.
-      set {_ops} to getOpsInBlock(loop-value,false)
-
-      loop {_ops}.size() times:
-        set {_tx} to loop-number - 1
-        #
-        # > Only go forward if the operation contains json.
-        if try {_ops}.get({_tx}).getOp().getJson() is set:
-          #
-          # > Only go forward of the required posting auths match with the requested steem username.
-          if "%{_ops}.get({_tx}).getOp().getRequiredPostingAuths().get(0)%" contains "name=%{_steemname}%":
-            #
-            # > Tell the player how the loading process is doing.
-            {_bossbar}.setTitle("&lLoading... [%{_partnumber} * {_pdone}%%%]")
-            set {_progress} to (({_partnumber} * {_pdone})/100)/1.5
-            {_bossbar}.setProgress({_progress})
-            #
-            # > Get the json Metadata as a string and check if the world matches with the
-            # > world which should be loaded.
-            set {_json} to "%{_ops}.get({_tx}).getOp().getJson()%"
-            if {_json} contains """w"":""%{_shortworld}%":
-              set {_objectMapper} to new ObjectMapper()
-              set {_jsonNode} to {_objectMapper}.readTree({_json})
-              set {_x} to {_jsonNode}.get("x")
-              set {_z} to {_jsonNode}.get("z")
-              set {_i} to {_jsonNode}.get("i")
-              set {_data} to {_jsonNode}.get("data").textValue()
-
-              set {_plotparts::%{_x}%|%{_z}%|%{_i}%} to {_data}
-    #
-    # > Tell the player about the current status.
-    {_bossbar}.setTitle("&lDecompressing world...")
-    set {_progress} to 0.5
-    {_bossbar}.setProgress({_progress})
-
-    #
-    # > Set some variables to calculate the percentage of a loaded world.
-    set {_partnumber} to 0
-    set {_plotsize} to size of {_plotpartamount::*}
-    set {_pdone} to 100 / {_plotsize}
-
-    #
-    # > Set the chunk parts together to one big chunk.
-    loop {_plotpartamount::*}:
-      set {_data} to ""
-      loop loop-value times:
-        set {_data} to "%{_data}%%{_plotparts::%loop-index-1%|%loop-number%}%"
-	  
       #
       # > Decompress the big chunk data, save it to file and load it.
-      set {_chunkcoord::*} to loop-index-1 split at "|"
+      set {_loop-value} to loop-value
+      set {_chunkcoord::*} to {_loop-value} split at "|"
 
       #
       # > The chunk coordinates are needed to load the chunks at the right
@@ -784,7 +683,7 @@ function loadSteemWorld(steemname:text,worldname:text,player:player):
       #
       # > Decompress and save the data to a schematic file to allow other programs
       # > to load and insert it into the world of the server.
-      set {_body} to decompressBase64({_data})
+      set {_body} to decompressBase64({_worlddata}.get({_loop-value}))
       set {_newbytes} to Base64ToBytes({_body})
       set {_file} to new File("tmp/%{_txid}%_%{_x}%_%{_z}%.schem")
       FileUtils.writeByteArrayToFile({_file}, {_newbytes})
@@ -843,6 +742,158 @@ function loadSteemWorld(steemname:text,worldname:text,player:player):
     # > to the players, only deleting it is not enough.
     {_bossbar}.removeAll()
     delete {_bossbar}
+
+#
+# > Function - loadSteemWorldData
+# > Loads a steem based world.
+# > Parameters:
+# > <text> steem name
+# > <text> world name
+# > [<BossBar>] a Bukkit bossbar to update the current progress
+# > Returns:
+# > <Hashmap>["response",SteemJ response],["world",<HashMap>["chunkid","base64 string"]]
+function loadSteemWorldData(steemname:text,worldname:text,bossbar:object=null) :: object:
+  #
+  # > Set the permlink to allow getting the comment content.
+  set {_permlink} to "re-steemcraft-%{_worldname}%"
+
+  #
+  # > Load the content using getSteemContentAsync without thread,
+  # > since we're already in a thread.
+  set metadata value "SteemContentRequest" of getDummy() to [{_steemname},{_permlink}]
+
+  getSteemContentAsync(metadata value "SteemContentRequest" of getDummy())
+
+  #
+  # > Create a HashMap which stores all the data.
+  set {_map} to new HashMap()
+
+  #
+  # > Get the Steem content response.
+  set {_c} to getSteemContentResponse({_steemname},{_permlink})
+  {_map}.put("response",{_c})
+
+  #
+  # > Reading the json metadata of the content is done using ObjectMapper.
+  set {_objectMapper} to new ObjectMapper()
+  set {_jsonNode} to {_objectMapper}.readTree({_c}.getJsonMetadata())
+
+  #
+  # > Get the compressed and base64 encoded string.
+  set {_plot} to {_jsonNode}.get("world").textValue()
+
+  #
+  # > The shortworld is used for short storage names.
+  set {_shortworld} to {_worldname}
+  replace "steemworlds-" with "" in {_shortworld}
+
+  #
+  # > Get the serialized location and save it to the storage.
+  set {_spawn} to {_jsonNode}.get("spawn").textValue()
+  saveGeneralStorageData("steemworlds",{_shortworld},"spawn",{_spawn})
+
+  #
+  # > Set the world size to the defined size in the Steem comment.
+  set {_size} to {_jsonNode}.get("wsize").doubleValue()
+  set {_size} to {_size}*32
+  set {_wb} to {_world}.getWorldBorder()
+  {_wb}.setWarningDistance(0)
+  {_wb}.setSize({_size})
+
+  #
+  # > Decompress and decode the base64 string, this increases the size.
+  set {_plot} to decompressBase64({_plot})
+
+  #
+  # > Since we now have a string, it has to be loaded using jackson again,
+  # > to access it later.
+  set {_plot} to {_objectMapper}.readTree({_plot})
+
+  #
+  # > Get all the block numers to load the chunks.
+  loop {_plot}.size().longValue() times:
+    set {_plotpart} to {_plot}.get(loop-number - 1)
+    set {_x} to {_plotpart}.get("x")
+    set {_z} to {_plotpart}.get("z")
+    set {_i} to {_plotpart}.get("i")
+    set {_b} to {_plotpart}.get("b").textValue()
+
+    set {_plotparts::%{_x}%|%{_z}%|%{_i}%} to {_b} parsed as number
+    add 1 to {_plotpartamount::%{_x}%|%{_z}%}
+
+  #
+  # > Get the size of the plotparts to give the player a loading bar.
+  set {_plotsize} to size of {_plotparts::*}
+  set {_pdone} to 100 / {_plotsize}
+
+  #
+  # > Loop through the parts of the world and gather the needed
+  # > informations.
+  loop {_plotparts::*}:
+    add 1 to {_partnumber}
+
+    #
+    # > Get the operations of a block.
+    set {_ops} to getOpsInBlock(loop-value,false)
+
+    loop {_ops}.size() times:
+      set {_tx} to loop-number - 1
+      #
+      # > Only go forward if the operation contains json.
+      if try {_ops}.get({_tx}).getOp().getJson() is set:
+        #
+        # > Only go forward of the required posting auths match with the requested steem username.
+        if "%{_ops}.get({_tx}).getOp().getRequiredPostingAuths().get(0)%" contains "name=%{_steemname}%":
+          if {_bossbar} is not null:
+            #
+            # > Tell the player how the loading process is doing.
+            {_bossbar}.setTitle("&lLoading... [%{_partnumber} * {_pdone}%%%]")
+            set {_progress} to (({_partnumber} * {_pdone})/100)/1.5
+            {_bossbar}.setProgress({_progress})
+          #
+          # > Get the json Metadata as a string and check if the world matches with the
+          # > world which should be loaded.
+          set {_json} to "%{_ops}.get({_tx}).getOp().getJson()%"
+          if {_json} contains """w"":""%{_shortworld}%":
+            set {_objectMapper} to new ObjectMapper()
+            set {_jsonNode} to {_objectMapper}.readTree({_json})
+            set {_x} to {_jsonNode}.get("x")
+            set {_z} to {_jsonNode}.get("z")
+            set {_i} to {_jsonNode}.get("i")
+            set {_data} to {_jsonNode}.get("data").textValue()
+
+            set {_plotparts::%{_x}%|%{_z}%|%{_i}%} to {_data}
+
+  if {_bossbar} is not null:
+    #
+    # > Tell the player about the current status.
+    {_bossbar}.setTitle("&lDecompressing world...")
+    set {_progress} to 0.5
+    {_bossbar}.setProgress({_progress})
+
+  #
+  # > Set some variables to calculate the percentage of a loaded world.
+  set {_partnumber} to 0
+  set {_plotsize} to size of {_plotpartamount::*}
+  set {_pdone} to 100 / {_plotsize}
+
+  #
+  # > Create a HashMap which contains the world data.
+  set {_finalparts} to new HashMap()
+
+  #
+  # > Set the chunk parts together to one big chunk.
+  loop {_plotpartamount::*}:
+    set {_data} to ""
+    loop loop-value times:
+      set {_data} to "%{_data}%%{_plotparts::%loop-index-1%|%loop-number%}%"
+    {_finalparts}.put(loop-index,{_data})
+
+  {_map}.put("world",{_finalparts})
+
+  delete {_finalparts}
+
+  return {_map}
 
 #
 # > Function - createSteemWorld


### PR DESCRIPTION
This pull request adds the ` function loadSteemWorldData(steemname:text,worldname:text,bossbar:object=null)` function which is going to allow other functions and commands to get the steem world data, like steem response for custom json metadata and all chunks base64 encoded.

This function has to be called within a thread, otherwise it will result in lag for the server.

- [x] Works as expected
- [x] Loading worlds still works like before
- [x] Loading without errors