### PR TITLE
Added getSteemWorldGamerule function

### DIFF
--- a/STEEM.CRAFT/addons/steemworlds.sk
+++ b/STEEM.CRAFT/addons/steemworlds.sk
@@ -1,6 +1,6 @@
 #
 # ==============
-# steemworlds.sk v0.0.23
+# steemworlds.sk v0.0.24
 # ==============
 # steemworlds.sk is part of the STEEM.CRAFT addons.
 # ==============
@@ -1254,6 +1254,16 @@ function setSteemWorldBiome(world:world,biome:text):
 function setSteemWorldGamerule(world:world,gamerule:text,setting:object):
   set {_gamerule} to GameRule.getByName({_gamerule})
   {_world}.setGameRule({_gamerule},{_setting})
+
+#
+# > Function - getSteemWorldGamerule
+# > Returns the gamerule value of the world.
+# > Parameters:
+# > <world>the world
+# > <text>the vanilla gamerule name of which the set value should be returned
+function getSteemWorldGamerule(world:world,gamerule:text) :: object:
+  set {_gamerule} to GameRule.getByName({_gamerule})
+  return {_world}.getGameRuleValue({_gamerule})
 
 #
 # > Event - on WorldInitEvent


### PR DESCRIPTION
This pull request is a follow-up to the previous pull request (https://github.com/Abwasserrohr/STEEM.CRAFT/pull/36). I forgot to add a function to get the gamerule of the world, which can be quite important, since it is nice to know the gamerule before actually changing it.

- [x] Works as expected
- [x] Loads without errors

Needed for: https://github.com/Abwasserrohr/STEEM.CRAFT/issues/32, https://github.com/Abwasserrohr/STEEM.CRAFT/issues/31

