### PR TITLE
Added steem world version history menu

### DIFF
--- a/STEEM.CRAFT/addons/steemworlds-gui.sk
+++ b/STEEM.CRAFT/addons/steemworlds-gui.sk
@@ -1,6 +1,6 @@
 #
 # ==============
-# steemworlds-gui.sk v0.0.2
+# steemworlds-gui.sk v0.0.3
 # ==============
 # steemworlds-gui.sk is part of the STEEM.CRAFT addons (addon to steemworlds.sk).
 # ==============
@@ -22,6 +22,12 @@ options:
   # > The settings item is the item which moves the player to the settings menu if clicked.
   settingsitem: getcustomhead("Settings","eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZTViZTIyYjVkNGE4NzVkNzdkZjNmNzcxMGZmNDU3OGVmMjc5MzlhOTY4NGNiZGIzZDMxZDk3M2YxNjY4NDkifX19","80272ba4-e5b6-48a7-8bfb-59212b25e1dd")
   #
+  # > Page forward item
+  forwarditem: getcustomhead("Forwarditem","eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZDllY2NjNWMxYzc5YWE3ODI2YTE1YTdmNWYxMmZiNDAzMjgxNTdjNTI0MjE2NGJhMmFlZjQ3ZTVkZTlhNWNmYyJ9fX0=","1fb90fc9-62ea-47d6-bfed-9b0887df7bef")
+  #
+  # > Page backwards item
+  backwarditem: getcustomhead("Backwarditem","eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvODY0Zjc3OWE4ZTNmZmEyMzExNDNmYTY5Yjk2YjE0ZWUzNWMxNmQ2NjllMTljNzVmZDFhN2RhNGJmMzA2YyJ9fX0=","2b2bcd29-7e28-4569-85c1-662936f813d5")
+  #
   # > The history item will move the player to the world save history menu.
   historyitem: clock
   #
@@ -39,6 +45,10 @@ options:
   #
   # > The back item will move the player back to the previous menu.
   backitem: redstone
+
+import:
+  com.fasterxml.jackson.databind.ObjectMapper
+  java.util.Date
 
 #
 # > Command - /steemworlds [ /sw, /sc ]
@@ -75,7 +85,7 @@ function openSteemWorldMainMenu(world:world,player:player):
   setguiitem({_player},11, {_commentitem},1, "&rComments","&7This feature is going to be\n&7added in a upcoming version.","")
 
   set {_historyitem} to {@historyitem}
-  setguiitem({_player},12, {_historyitem},1, "&rWorld history","&7This feature is going to be\n&7added in a upcoming version.","")
+  setguiitem({_player},12, {_historyitem},1, "&rWorld history","&7View and load older versions\n&7of this world here.","openSteemWorldHistoryMenu(""%{_world}%"" parsed as world, 1, ""%{_player}%"" parsed as player)")
 
   setguiitem({_player},16, {@settingsitem},1, "&rSettings","&7Click here to open the\n&7settings for this world.","openSteemWorldSettingsMenu(""%{_world}%"" parsed as world, ""%{_player}%"" parsed as player)")
 
@@ -329,6 +339,13 @@ function waitSteemWorldmenu(player:player,start:boolean=true):
       wait 5 ticks
 
 #
+# > Event - on inventory close
+# > Removes the wait menu updates if the menu gets closed.
+on inventory close:
+  if metadata value "waitSteemWorldmenu" of player is set:
+    delete metadata value "waitSteemWorldmenu" of player
+
+#
 # > Function - changeSteemWorldSettingInMenu
 # > Changes settings like weather or time and is used in menues.
 # > Parameters:
@@ -373,3 +390,180 @@ function changeSteemWorldGameruleInMenu(world:world,gamerule:text,value:object,p
     # > Change the settings and then re-open the menu for settings.
     setSteemWorldGamerule({_world},{_gamerule},{_value})
     openSteemWorldSettingsMenu({_world},{_player})
+
+#
+# > Function - openSteemWorldHistoryMenu
+# > Opens a menu which allows to view and load any version of the steem world.
+# > Parameters:
+# > <world>the world
+# > <number>the history menu site number
+# > <player>the player who wants to open this menu
+# > [<boolean>]initializing this menu will look for newer versions, default: true
+function openSteemWorldHistoryMenu(world:world,site:number,player:player,init:boolean=true):
+  #
+  # > Use the ObjectMapper to save and load data using JSON.
+  set {_objectMapper} to new ObjectMapper()
+
+  if {_init} is true:
+    set {_steemusername} to "immanuel94"
+    set {_permlink} to "re-steemcraft-%{_world}%"
+
+    waitSteemWorldmenu({_player},true)
+	
+    #
+    # > Check if the world exists on Steem.
+    getSteemContent({_steemusername},{_permlink})
+
+    #
+    # > Wait until the Steem content response is no longer "wait".
+    while getSteemContentResponse({_steemusername},{_permlink}) is "wait":
+      wait 1 tick
+
+    #
+    # > Get the Steem content response.
+    set {_c} to getSteemContentResponse({_steemusername},{_permlink})
+
+    #
+    # > Only go and check for new history data, if the last update is not the same as the local one
+    # > and if no history data is available.
+    if {_c}.getLastUpdate().getDateTimeAsInt() is getGeneralStorageData("steemworlds",getSteemWorldShortName({_world}),"lastupdate"):
+      if getGeneralStorageData("steemworlds",getSteemWorldShortName({_world}),"history") is set:
+        set {_ok} to true
+
+    #
+    # > Outdated or no history has been found, get new history data and cache it.
+    if {_ok} is not true:
+
+      getSteemWorldHistory({_steemusername},"%{_world}%")
+
+      #
+      # > Getting the history data from steem can take some time, which is why it is done in a thread.
+      while getSteemWorldHistoryResult({_steemusername},"%{_world}%") is "wait":
+        wait 1 tick
+      
+      #
+      # > The waiting is over, stop the waiting menu.
+      waitSteemWorldmenu({_player},false)
+
+      #
+      # > Get the result to then cache it sorted.
+      set {_t} to getSteemWorldHistoryResult({_steemusername},"%{_world}%")
+
+      #
+      # > To cache the data easily accessible and fast to read, use JSON.
+      set {_history} to {_objectMapper}.createObjectNode()
+      set {_saves::*} to sorted ...{_t}.keySet()
+
+      loop {_saves::*}:
+        {_history}.put("%loop-value%", "%{_t}.get(loop-value)%")
+
+      wait 1 tick
+
+      #
+      # > Save the retrieved data into the cache.
+      saveGeneralStorageData("steemworlds",getSteemWorldShortName({_world}),"history", {_history}.toString())
+      
+      #
+      # > Wait to allow the server to catch up.
+      wait 2 ticks
+
+  #
+  # > Get the cached data and parse it to display the data using ObjectMapper.
+  set {_history} to getGeneralStorageData("steemworlds",getSteemWorldShortName({_world}),"history")
+
+  set {_saves} to {_objectMapper}.readTree({_history})
+
+  #set {_saves::*} to ...{_saves}
+  set {_keys::*} to ...{_saves}.fieldNames()
+    
+  loop {_keys::*}:
+    add 1 to {_versions}
+    set {_time} to new Date("%{_saves}.get(loop-value).textValue()%" parsed as number * 1000)
+    set {_final::%loop-value%} to {_time}
+
+  #
+  # > Set the maximum amount of versions that should be displayed
+  # > per site. For a better look, use 21 versions per site.
+  # > These settings can be ajusted but will change the layout of
+  # > the world history menu a lot.
+  set {_sizelimit} to 21
+  set {_slot} to 9
+  set {_slotskipat} to 8
+  set {_slotskipamount} to 2
+
+  #
+  # > If the player is allowed to load the world, the menu will allow
+  # > to load different world versions directly from the menu.
+  if getWorldPermission({_world},{_player},"load") is true:
+    set {_loadallowed} to true
+
+  opengui({_player},45,"&lWorld history")
+
+  #
+  # > Cover all inventory menu slots with a background item
+  # > to prevent item loss for players.
+  loop 45 times:
+    setguiitem({_player},loop-number - 1, {@backgrounditem},1, " ","")
+
+  #
+  # > Loop through all world versions and create a viewable menu.
+  loop {_final::*}:
+
+    #
+    # > Count up for every world version.
+    add 1 to {_loopid}
+	
+    #
+    # > Depending on the current site, calculate at which entry the site ends.
+    set {_siteend} to {_sizelimit}*{_site}
+
+    #
+    # > Depending on the end of the site, calculate at which entry the site starts.
+    set {_sitestart} to {_siteend} - {_sizelimit}
+	
+    #
+    # > Only show entries that are higher than the site start variable
+    # > and equal or lower than the site end variable.
+    if {_loopid} > {_sitestart}:
+      if {_loopid} <= {_siteend}:
+
+        #
+        # > Skip some slots every predefined amount of slots for improve
+        # > the layout of the menu.
+        add 1 to {_nextslotskip}
+        if {_nextslotskip} is {_slotskipat}:
+          add {_slotskipamount} to {_slot}
+          set {_nextslotskip} to 1
+
+        #
+        # > To not overwrite any slots, increase the current slot always by 1.
+        add 1 to {_slot}
+
+        #
+        # > Create a different item with function if the player is allowed to load
+        # > the world. If not allowed, the lore (subtext of item) is changed.
+        if {_loadallowed} is true:
+          setguiitem({_player},{_slot}, {@enableditem},1, "&r&lWorld version %{_loopid}%","&7Block: %loop-index%\n&7Date: %loop-value%\n&7Click &6here&7 to load this version.","make ""%{_player}%"" parsed as player execute ""/steemworldload %loop-index%""",true)
+        else:
+          setguiitem({_player},{_slot}, {@enableditem},1, "&r&lWorld version %{_loopid}%","&7Block: %loop-index%\n&7Date: %loop-value%")
+
+      #
+      # > If the id of this entry is bigger than the site end variable,
+      # > we have to add a item which allows to go to the next page.
+      else:
+        setguiitem({_player},26, {@forwarditem},1, "&r&lSite %{_site}+1%","","openSteemWorldHistoryMenu(""%{_world}%"" parsed as world,%{_site}+1%,""%{_player}%"" parsed as player,false)")
+        
+        #
+        # > Since we're done here, stop this loop.
+		stop loop
+
+  #
+  # > If we're on a site that is higher than 1, add a item
+  # > which allows to get back to the previous page (site).
+  if {_site} > 1:
+    setguiitem({_player},18, {@backwarditem},1, "&r&lSite %{_site}-1%","","openSteemWorldHistoryMenu(""%{_world}%"" parsed as world,%{_site}-1%,""%{_player}%"" parsed as player,false)")
+
+  #
+  # > Add a item which allows the player to get back to the
+  # > previous menu. In this case, the steem world main menu.
+  setguiitem({_player},36, {@backitem},1, "&rBack","&7Click here to get\n&7back to the\n&7previous menu.","openSteemWorldMainMenu(""%{_world}%"" parsed as world, ""%{_player}%"" parsed as player)")

--- a/STEEM.CRAFT/addons/steemworlds.sk
+++ b/STEEM.CRAFT/addons/steemworlds.sk
@@ -1,6 +1,6 @@
 #
 # ==============
-# steemworlds.sk v0.0.30
+# steemworlds.sk v0.0.31
 # ==============
 # steemworlds.sk is part of the STEEM.CRAFT addons.
 # ==============
@@ -183,7 +183,7 @@ command /steemworldload [<number=0>]:
     # > To show off that saving and loading works, there is a single world per
     # > user, which is hardcoded for now. It is always named "steemworlds-steemusername-worldname"
     if "%player's world%" contains "steemworlds-":
-	  set {_name} to getSteemWorldShortName(player's world)
+      set {_name} to getSteemWorldShortName(player's world)
       set {_account} to getGeneralStorageData("steemworlds",{_name},"steemaccount")
       #
       # > The following process needs to be executed as a thread, a global variable
@@ -1143,7 +1143,7 @@ function getSteemWorldHistoryAsync(request:object):
         if {_history}.get(loop-value).getOp().getPermlink().getLink() is {_searchedpermlink}:
           #
           # > Add the block number and metadata of this world to the revisions HashMap.
-          {_revisions}.put({_history}.get(loop-value).getBlock().intValue(),{_history}.get(loop-value).getOp().getJsonMetadata())
+          {_revisions}.put({_history}.get(loop-value).getBlock().intValue(),{_history}.get(loop-value).getTimestamp().getDateTimeAsInt())
 
           #
           # > If this transaction has reached or somehow even exceeded the creation date of the


### PR DESCRIPTION
This pull request aims to adds a menu which allows to view and load older versions of the steem world. There should be no limit on the versions and be possible to view every version by using multiple pages.

- [x] Works as expected
- [x] Loads without errros

Here is a video of the new menu: https://youtu.be/aoPit6l83Jg

Close https://github.com/Abwasserrohr/STEEM.CRAFT/issues/25https://github.com/Abwasserrohr/STEEM.CRAFT/issues/25 once merged.

