### PR TITLE
Added command execution prevention for steemworlds.sk

### DIFF
--- a/STEEM.CRAFT/addons/steemworlds.sk
+++ b/STEEM.CRAFT/addons/steemworlds.sk
@@ -1,6 +1,6 @@
 #
 # ==============
-# steemworlds.sk v0.0.31
+# steemworlds.sk v0.0.32
 # ==============
 # steemworlds.sk is part of the STEEM.CRAFT addons.
 # ==============
@@ -77,6 +77,7 @@ import:
   org.bukkit.World$Environment
   org.bukkit.WorldType
   org.bukkit.event.world.WorldInitEvent
+  org.bukkit.event.server.ServerCommandEvent
   org.bukkit.GameRule
   com.boydti.fawe.object.schematic.Schematic
   com.sk89q.worldedit.regions.CuboidRegion
@@ -1443,3 +1444,16 @@ function getSteemWorldShortName(world:world) :: text:
 on WorldInitEvent with priority HIGHEST:
   if "%event.getWorld()%" contains "steemworlds-":
     event.getWorld().setKeepSpawnInMemory(false)
+
+#
+# > Event - ServerCommandEvent
+# > Stops all commands which are executed by command blocks and
+# > command block minecarts and senders which might be able
+# > to send from a steem based world.
+on ServerCommandEvent:
+  if try event.getSender().getBlock() is set:
+    if "%event.getSender().getBlock().getWorld()%" contains "steemworlds-":
+      cancel event
+  else:
+    if "%event.getSender().getWorld()%" contains "steemworlds-":
+      cancel event


### PR DESCRIPTION
This pull request adds a protection against any commands which might get loaded. It is not possible to run any command blocks or command block minecarts within a steem based world due to security reasons.

- [x] Works as expected
- [x] Loads without errors

Close https://github.com/Abwasserrohr/STEEM.CRAFT/issues/41 once merged.