### PR TITLE
SteemBans

### DIFF
--- a/STEEM.CRAFT/addons/steembans/commands/SteemBans.sk
+++ b/STEEM.CRAFT/addons/steembans/commands/SteemBans.sk
@@ -1,0 +1,33 @@
+#
+# ==============
+# SteemBans.sk
+# ==============
+# SteemBans.sk is part of the STEEM.CRAFT addons.
+# ==============
+
+command /steembans [<text>] [<text>] [<text>]:
+  aliases: /steemban, /stemban, /stembans
+  trigger:
+    if arg-1 is "reload":
+      make player execute "/sk reload STEEM.CRAFT/addons/steembans/"
+    else if arg-1 is "help":
+      set {_prefix} to getChatPrefix()
+      message "%{_prefix}% Available commands:"
+      message "%{_prefix}% /ban <player> <reason>"
+      message "%{_prefix}% /unban <player> <reason>"
+      message "%{_prefix}% /mute <player> <reason>"
+      message "%{_prefix}% /unmute <player> <reason>"
+      message "%{_prefix}% /warn <player> <reason>"
+      message "%{_prefix}% /kick <player> <reason>"
+    if arg-1 is "check":
+      set {_player} to arg-2 parsed as offline player
+      if {_player} is set:
+        SteemBansGetPlayerBanned({_player})
+        while SteemBansRetrievePlayerBanned({_player}) is "wait":
+          wait 1 tick
+        set {_banned} to SteemBansRetrievePlayerBanned({_player})
+        if {_banned} is true:
+          message "%getChatPrefix()% %{_player}% &lis&7 banned."
+        else:
+          message "%getChatPrefix()% %{_player}% &lis not&7 banned."
+

--- a/STEEM.CRAFT/addons/steembans/commands/SteemBans.sk
+++ b/STEEM.CRAFT/addons/steembans/commands/SteemBans.sk
@@ -20,14 +20,5 @@ command /steembans [<text>] [<text>] [<text>]:
       message "%{_prefix}% /warn <player> <reason>"
       message "%{_prefix}% /kick <player> <reason>"
     if arg-1 is "check":
-      set {_player} to arg-2 parsed as offline player
-      if {_player} is set:
-        SteemBansGetPlayerBanned({_player})
-        while SteemBansRetrievePlayerBanned({_player}) is "wait":
-          wait 1 tick
-        set {_banned} to SteemBansRetrievePlayerBanned({_player})
-        if {_banned} is true:
-          message "%getChatPrefix()% %{_player}% &lis&7 banned."
-        else:
-          message "%getChatPrefix()% %{_player}% &lis not&7 banned."
-
+      if player has permission "steembans.check":
+        SteemBansGetPlayerInfo(arg-2 parsed as offline player,player)

--- a/STEEM.CRAFT/addons/steembans/commands/ban.sk
+++ b/STEEM.CRAFT/addons/steembans/commands/ban.sk
@@ -1,0 +1,20 @@
+#
+# ==============
+# ban.sk
+# ==============
+# ban.sk is part of the STEEM.CRAFT addons.
+# ==============
+
+command /ban <offline player> [<text>]:
+  aliases: /sban, /scban
+  permission: steembans.ban
+  trigger:
+    if arg-1 is set:
+      if arg-2 is set:
+        set {_reason} to arg-2
+      else:
+        set {_reason} to "-"
+      set {_bannedplayer} to arg-1
+      SteemBansBanPlayer(player,{_bannedplayer},{_reason})
+    else:
+      make player execute "/steembans help"

--- a/STEEM.CRAFT/addons/steembans/commands/kick.sk
+++ b/STEEM.CRAFT/addons/steembans/commands/kick.sk
@@ -1,0 +1,20 @@
+#
+# ==============
+# kick.sk
+# ==============
+# kick.sk is part of the STEEM.CRAFT addons.
+# ==============
+
+command /kick <offline player> [<text>]:
+  aliases: /skick, /sckick
+  permission: steembans.kick
+  trigger:
+    if arg-1 is set:
+      if arg-2 is set:
+        set {_reason} to arg-2
+      else:
+        set {_reason} to "-"
+      set {_kickedplayer} to arg-1
+      SteemBansKickPlayer(player,{_kickedplayer},{_reason})
+    else:
+      make player execute "/steembans help"

--- a/STEEM.CRAFT/addons/steembans/commands/unban.sk
+++ b/STEEM.CRAFT/addons/steembans/commands/unban.sk
@@ -1,0 +1,20 @@
+#
+# ==============
+# unban.sk
+# ==============
+# unban.sk is part of the STEEM.CRAFT addons.
+# ==============
+
+command /unban <offline player> [<text>]:
+  aliases: /sunban, /scunban
+  permission: steembans.unban
+  trigger:
+    if arg-1 is set:
+      if arg-2 is set:
+        set {_reason} to arg-2
+      else:
+        set {_reason} to "-"
+      set {_unbanplayer} to arg-1
+      SteemBansUnbanPlayer(player,{_unbanplayer},{_reason})
+    else:
+      make player execute "/steembans help"

--- a/STEEM.CRAFT/addons/steembans/commands/warn.sk
+++ b/STEEM.CRAFT/addons/steembans/commands/warn.sk
@@ -1,0 +1,20 @@
+#
+# ==============
+# warn.sk
+# ==============
+# warn.sk is part of the STEEM.CRAFT addons.
+# ==============
+
+command /warn <offline player> [<text>]:
+  aliases: /swarn, /scwarn
+  permission: steembans.warn
+  trigger:
+    if arg-1 is set:
+      if arg-2 is set:
+        set {_reason} to arg-2
+      else:
+        set {_reason} to "-"
+      set {_warnedplayer} to arg-1
+      SteemBansWarnPlayer(player,{_warnedplayer},{_reason})
+    else:
+      make player execute "/steembans help"

--- a/STEEM.CRAFT/addons/steembans/events/onjoin.sk
+++ b/STEEM.CRAFT/addons/steembans/events/onjoin.sk
@@ -1,15 +1,30 @@
+#
+# ==============
+# onjoin.sk
+# ==============
+# onjoin.sk is part of the STEEM.CRAFT addons.
+# ==============
 
+import:
+  org.bukkit.event.player.PlayerLoginEvent 
 
-
-on join:
-  SteemBansGetPlayerBanned(player)
-  while SteemBansRetrievePlayerBanned(player) is "wait":
+#
+# > PlayerLoginEvent
+# > Triggered when a player logs on the server.
+# > Checks if the player is banned and bans the
+# > player. If the player has been unbanned and
+# > is still banned, the player gets unbanned.
+on PlayerLoginEvent with priority highest:
+  set {_player} to event.getPlayer()
+  event.setKickMessage("It seems that you have been banned. &lYou got unbanned? Try again.")
+  SteemBansGetPlayerBanned({_player})
+  while SteemBansRetrievePlayerBanned({_player}) is "wait":
     wait 1 tick
-  set {_banned} to SteemBansRetrievePlayerBanned(player)
+  set {_banned} to SteemBansRetrievePlayerBanned({_player})
   if {_banned} is true:
-    kick player because of "You're banned on this server."
-    if player is not banned:
-      ban player
+    if {_player} is not banned:
+      ban {_player}
   else:
-    if player is banned:
-      unban player
+    if {_player} is banned:
+      unban {_player}
+      event.allow()

--- a/STEEM.CRAFT/addons/steembans/events/onjoin.sk
+++ b/STEEM.CRAFT/addons/steembans/events/onjoin.sk
@@ -1,0 +1,15 @@
+
+
+
+on join:
+  SteemBansGetPlayerBanned(player)
+  while SteemBansRetrievePlayerBanned(player) is "wait":
+    wait 1 tick
+  set {_banned} to SteemBansRetrievePlayerBanned(player)
+  if {_banned} is true:
+    kick player because of "You're banned on this server."
+    if player is not banned:
+      ban player
+  else:
+    if player is banned:
+      unban player

--- a/STEEM.CRAFT/addons/steembans/events/onload.sk
+++ b/STEEM.CRAFT/addons/steembans/events/onload.sk
@@ -1,0 +1,10 @@
+#
+# ==============
+# onload.sk
+# ==============
+# onload.sk is part of the STEEM.CRAFT addons.
+# ==============
+
+on load:
+  wait 1 tick
+  SteemBansLoadConfig()

--- a/STEEM.CRAFT/addons/steembans/functions/SteemBansBanPlayer.sk
+++ b/STEEM.CRAFT/addons/steembans/functions/SteemBansBanPlayer.sk
@@ -16,6 +16,7 @@
 # > [<text>] The reason, why the player is banned, can be empty.
 function SteemBansBanPlayer(executor:object,bannedplayer:offline player,reason:text="-"):
   message "%getChatPrefix()% Trying to ban %{_bannedplayer}%..." to {_executor}
+  ban {_bannedplayer} because of {_reason}
   set {_steemname} to getServerAccountName()
 
   set {_requestid} to getRawSteemContent({_steemname},"re-steemcraft-bans")

--- a/STEEM.CRAFT/addons/steembans/functions/SteemBansBanPlayer.sk
+++ b/STEEM.CRAFT/addons/steembans/functions/SteemBansBanPlayer.sk
@@ -1,0 +1,50 @@
+#
+# ==============
+# SteemBansBanPlayer.sk
+# ==============
+# SteemBansBanPlayer.sk is part of the STEEM.CRAFT addons.
+# ==============
+
+#
+# > Function - SteemBansBanPlayer
+# > Bans the defined player with the defined reason.
+# > A ban can fail and result in a not banned account,
+# > make sure the transactions doesn't return an error.
+# > Parameters:
+# > <player> The user who bans a player.
+# > <player> The player who should get banned.
+# > [<text>] The reason, why the player is banned, can be empty.
+function SteemBansBanPlayer(executor:object,bannedplayer:offline player,reason:text="-"):
+  message "%getChatPrefix()% Trying to ban %{_bannedplayer}%..." to {_executor}
+  set {_steemname} to getServerAccountName()
+
+  set {_requestid} to getRawSteemContent({_steemname},"re-steemcraft-bans")
+  while CustomSteemRequestResult({_requestid}) is "wait":
+    wait 1 tick
+  set {_parent} to CustomSteemRequestResult({_requestid})
+  if {_parent}.get("result").get("author").textValue() is "":
+    message "%getChatPrefix()% Creating parent..." to {_executor}
+    set {_txuuid} to "bans"
+    set {_comment} to "Bans of the server @%{_steemname}%."
+    set {_parentauthor} to "steem.craft"
+    set {_parentpermlink} to "bans"
+    createComment({_txuuid},{_steemname},{_comment},{_parentauthor},{_parentpermlink},getDefaultAppTags(),"Bans")
+    while getSteemResponse({_txuuid}) is "wait":
+      wait 1 tick
+    message "%getChatPrefix()% Parent creation successful." to {_executor}
+    wait 5 seconds
+
+  set {_uuid} to uuid of {_bannedplayer}
+  set {_txuuid} to "ban-%{_uuid}%"
+  set {_comment} to "<table><tr><td><strong>User</strong></td><td><strong>Banned by</strong></td><td><strong>Reason</strong></td><td><strong>Date</strong></td><td><strong>Status</strong></td><tr><td>%{_uuid}%</td><td>%uuid of {_executor}%</td><td>%{_reason}%</td><td>%now%</td><td>BANNED</td></tr></table>"
+  set {_parentauthor} to {_steemname}
+  set {_parentpermlink} to "re-steemcraft-bans"
+  createComment({_txuuid},{_steemname},{_comment},{_parentauthor},{_parentpermlink},getDefaultAppTags(),"Ban","{""tags"":[""steemcraft""],""app"":""%getAppName()%"",""format"":""markdown"",""ban"":""banned"",""executed"":""%uuid of {_executor}%"",""bantime"":-1}")
+  while getSteemResponse({_txuuid}) is "wait":
+    wait 1 tick
+
+  if getSteemResponse({_txuuid}) is "done":
+    message "%getChatPrefix()% %{_bannedplayer}% has been banned." to {_executor}
+    message "%getChatPrefix()% It may take 30 seconds to take effect globally." to {_executor}
+  else:
+    message "%getChatPrefix()% A error occured: %getSteemResponse({_txuuid})%" to {_executor}

--- a/STEEM.CRAFT/addons/steembans/functions/SteemBansBanPlayer.sk
+++ b/STEEM.CRAFT/addons/steembans/functions/SteemBansBanPlayer.sk
@@ -39,12 +39,29 @@ function SteemBansBanPlayer(executor:object,bannedplayer:offline player,reason:t
   set {_comment} to "<table><tr><td><strong>User</strong></td><td><strong>Banned by</strong></td><td><strong>Reason</strong></td><td><strong>Date</strong></td><td><strong>Status</strong></td><tr><td>%{_uuid}%</td><td>%uuid of {_executor}%</td><td>%{_reason}%</td><td>%now%</td><td>BANNED</td></tr></table>"
   set {_parentauthor} to {_steemname}
   set {_parentpermlink} to "re-steemcraft-bans"
-  createComment({_txuuid},{_steemname},{_comment},{_parentauthor},{_parentpermlink},getDefaultAppTags(),"Ban","{""tags"":[""steemcraft""],""app"":""%getAppName()%"",""format"":""markdown"",""ban"":""banned"",""executed"":""%uuid of {_executor}%"",""bantime"":-1}")
+
+  set {_metadata} to JsonNode()
+  set {_tags} to ArrayNode()
+  loop ...getDefaultAppTags():
+    {_tags}.add(loop-value)
+  {_metadata}.put("tags", {_tags})
+  {_metadata}.put("app", getAppName())
+  {_metadata}.put("format", "markdown")
+  {_metadata}.put("ban", "banned")
+  {_metadata}.put("executed", uuid of {_executor})
+  {_metadata}.put("reason", {_reason})
+  {_metadata}.put("bantime", -1)
+
+  createComment({_txuuid},{_steemname},{_comment},{_parentauthor},{_parentpermlink},getDefaultAppTags(),"Ban",{_metadata}.toString())
   while getSteemResponse({_txuuid}) is "wait":
     wait 1 tick
 
   if getSteemResponse({_txuuid}) is "done":
     message "%getChatPrefix()% %{_bannedplayer}% has been banned." to {_executor}
     message "%getChatPrefix()% It may take 30 seconds to take effect globally." to {_executor}
+    if {_bannedplayer} is online:
+      kick {_bannedplayer} because of "You have been banned due to %{_reason}%"
+      ban {_bannedplayer} because of {_reason}
+
   else:
     message "%getChatPrefix()% A error occured: %getSteemResponse({_txuuid})%" to {_executor}

--- a/STEEM.CRAFT/addons/steembans/functions/SteemBansGetPlayerInfo.sk
+++ b/STEEM.CRAFT/addons/steembans/functions/SteemBansGetPlayerInfo.sk
@@ -1,0 +1,80 @@
+#
+# ==============
+# SteemBansGetPlayerBanned.sk
+# ==============
+# SteemBansGetPlayerBanned.sk is part of the STEEM.CRAFT addons.
+# ==============
+
+import:
+  java.util.ArrayList
+  com.fasterxml.jackson.databind.ObjectMapper
+
+#
+# > Function - SteemBansGetPlayerInfo
+# > Tells the executor if the player is banned and if
+# > there are any warns or kicks listed on Steem from
+# > the current server.
+# > Parameters:
+# > <offline player> The player about which the information is requested.
+# > <player> The player who requested the information.
+function SteemBansGetPlayerInfo(player:offline player,executor:player):
+  if {_player} is set:
+    SteemBansGetPlayerBanned({_player})
+    while SteemBansRetrievePlayerBanned({_player}) is "wait":
+      wait 1 tick
+    set {_banned} to SteemBansRetrievePlayerBanned({_player})
+    message "%getChatPrefix()% ---------------------------------" to {_executor}
+    if {_banned} is true:
+      message "%getChatPrefix()% &l%{_player}% &7[&4&lBanned&7]" to {_executor}
+    else:
+      message "%getChatPrefix()% &l%{_player}% &7[&2&lUnbanned&7]" to {_executor}
+    set {_uuid} to uuid of {_player}
+    set {_server} to getServerAccountName()
+    set {_warnrequest} to getRawSteemContent({_server},"re-%{_server}%-warn-%{_uuid}%")
+    while CustomSteemRequestResult({_warnrequest}) is "wait":
+      wait 1 tick
+    set {_warn} to CustomSteemRequestResult({_warnrequest})
+    set {_ObjectMapper} to new ObjectMapper()
+    set {_warnlist} to new ArrayList()
+    if {_warn}.get("result").get("author").textValue() is not "":
+      set {_json} to {_ObjectMapper}.readTree({_warn}.get("result").get("json_metadata").textValue())
+      {_warnlist}.add({_json}.get("reason").textValue())
+      if {_warn}.get("result").get("children") is not 0:
+        set {_warnrequest} to getRawSteemContentReplies({_server},"re-%{_server}%-warn-%{_uuid}%")
+        while CustomSteemRequestResult({_warnrequest}) is "wait":
+          wait 1 tick
+        set {_warns} to CustomSteemRequestResult({_warnrequest})
+        loop ...{_warns}.get("result"):
+          if loop-value.get("author").textValue() is {_server}:
+            set {_json} to {_ObjectMapper}.readTree(loop-value.get("json_metadata").textValue())
+            {_warnlist}.add({_json}.get("reason").textValue())
+    if {_warnlist}.size() is not 0:
+      message "%getChatPrefix()% &lWarns (%{_warnlist}.size()%):" to {_executor}
+      loop ...{_warnlist}:
+        message "%getChatPrefix()% > %loop-value%" to {_executor}
+		
+    set {_warnrequest} to getRawSteemContent({_server},"re-%{_server}%-kick-%{_uuid}%")
+    while CustomSteemRequestResult({_warnrequest}) is "wait":
+      wait 1 tick
+    set {_kick} to CustomSteemRequestResult({_warnrequest})
+
+    set {_ObjectMapper} to new ObjectMapper()
+    set {_kicklist} to new ArrayList()
+    if {_kick}.get("result").get("author").textValue() is not "":
+      set {_json} to {_ObjectMapper}.readTree({_kick}.get("result").get("json_metadata").textValue())
+      {_kicklist}.add({_json}.get("reason").textValue())
+      if {_kick}.get("result").get("children") is not 0:
+        set {_warnrequest} to getRawSteemContentReplies({_server},"re-%{_server}%-kick-%{_uuid}%")
+        while CustomSteemRequestResult({_warnrequest}) is "wait":
+          wait 1 tick
+        set {_kicks} to CustomSteemRequestResult({_warnrequest})
+        loop ...{_kicks}.get("result"):
+          if loop-value.get("author").textValue() is {_server}:
+            set {_json} to {_ObjectMapper}.readTree(loop-value.get("json_metadata").textValue())
+            {_kicklist}.add({_json}.get("reason").textValue())
+    if {_kicklist}.size() is not 0:
+      message "%getChatPrefix()% &lKicks (%{_kicklist}.size()%):" to {_executor}
+      loop ...{_kicklist}:
+        message "%getChatPrefix()% > %loop-value%" to {_executor}
+
+    message "%getChatPrefix()% ---------------------------------" to {_executor}

--- a/STEEM.CRAFT/addons/steembans/functions/SteemBansIsPlayerBanned.sk
+++ b/STEEM.CRAFT/addons/steembans/functions/SteemBansIsPlayerBanned.sk
@@ -1,0 +1,55 @@
+#
+# ==============
+# SteemBansGetPlayerBanned.sk
+# ==============
+# SteemBansGetPlayerBanned.sk is part of the STEEM.CRAFT addons.
+# ==============
+
+import:
+  com.fasterxml.jackson.databind.ObjectMapper
+  java.lang.String
+
+#
+# > Function - SteemBansGetPlayerBanned
+# > Checks if the player is banned on one of the enforced servers.
+# > The result can be retrieved using SteemBansRetrievePlayerBanned(player).
+# > Parameters:
+# > <offline player> The player who should be checked.
+function SteemBansGetPlayerBanned(player:offline player):
+  set metadata value "SteemBans|Banned|%{_player}%" of getDummy() to "wait"
+  set {_enforcedservers} to getyamlconfigobject("steembans","enforcedservers")
+  set {_uuid} to uuid of {_player}
+  set {_ObjectMapper} to new ObjectMapper()
+
+  loop ...getyamlconfigobject("steembans","enforcedservers"):
+    set {_requestid} to getRawSteemContent("%loop-value%","re-skyroad-ban-%{_uuid}%")
+
+    while CustomSteemRequestResult({_requestid}) is "wait":
+      wait 1 tick
+    set {_parent} to CustomSteemRequestResult({_requestid})
+    if {_parent} is instance of String:
+      set {_banned} to false
+    else if {_parent}.get("result").get("author").textValue() is not loop-value:
+      set {_banned} to false
+    else:
+      set {_json} to {_parent}.get("result").get("json_metadata").textValue()
+      set {_json} to {_ObjectMapper}.readTree({_json})
+      if {_json}.get("ban") is set:
+        if {_json}.get("ban").textValue() is "banned":
+          set {_banned} to true
+          stop loop
+
+  if {_banned} is not set:
+    set {_banned} to false
+
+  set metadata value "SteemBans|Banned|%{_player}%" of getDummy() to {_banned}
+  wait 5 seconds
+  delete metadata value "SteemBans|Banned|%{_player}%" of getDummy()
+
+#
+# > Function - SteemBansRetrievePlayerBanned
+# > Returns a requested value if the player is banned or not.
+# > Pamrameters:
+# > <offline player> The requested player.
+function SteemBansRetrievePlayerBanned(player:offline player) :: object:
+  return metadata value "SteemBans|Banned|%{_player}%" of getDummy()

--- a/STEEM.CRAFT/addons/steembans/functions/SteemBansKickPlayer.sk
+++ b/STEEM.CRAFT/addons/steembans/functions/SteemBansKickPlayer.sk
@@ -1,0 +1,74 @@
+#
+# ==============
+# SteemBansKickPlayer.sk
+# ==============
+# SteemBansKickPlayer.sk is part of the STEEM.CRAFT addons.
+# ==============
+
+#
+# > Function - SteemBansKickPlayer
+# > Kick the player and creates a comment on Steem
+# > which allows everyone to check the kick.
+# > Parameters:
+# > <player> The user who kicks a player.
+# > <player> The player who should get kicked.
+# > [<text>] The reason, why the player is kicked, can be empty.
+function SteemBansKickPlayer(executor:object,kickedplayer:offline player,reason:text="-"):
+  if {_kickedplayer} is not online:
+    message "%getChatPrefix()% %{_kickedplayer}% is not online." to {_executor}
+    stop
+  else:
+    kick {_kickedplayer} because of {_reason}
+    message "%getChatPrefix()% %{_kickedplayer}% has been kicked." to {_executor}
+
+  set {_steemname} to getServerAccountName()
+
+  set {_requestid} to getRawSteemContent({_steemname},"re-steemcraft-kicks")
+  while CustomSteemRequestResult({_requestid}) is "wait":
+    wait 1 tick
+  set {_parent} to CustomSteemRequestResult({_requestid})
+  if {_parent}.get("result").get("author").textValue() is "":
+    message "%getChatPrefix()% Creating parent..." to {_executor}
+    set {_txuuid} to "kicks"
+    set {_comment} to "Kicks of the server @%{_steemname}%."
+    set {_parentauthor} to "steem.craft"
+    set {_parentpermlink} to "kicks"
+    createComment({_txuuid},{_steemname},{_comment},{_parentauthor},{_parentpermlink},getDefaultAppTags(),"Kicks")
+    while getSteemResponse({_txuuid}) is "wait":
+      wait 1 tick
+    message "%getChatPrefix()% Parent creation successful." to {_executor}
+    wait 5 seconds
+
+  set {_uuid} to uuid of {_kickedplayer}
+  set {_requestid} to getRawSteemContent({_steemname},"re-%{_steemname}%-kick-%{_uuid}%")
+  while CustomSteemRequestResult({_requestid}) is "wait":
+    wait 1 tick
+  set {_parent} to CustomSteemRequestResult({_requestid})
+  if {_parent}.get("result").get("author").textValue() is "":
+    set {_parentpermlink} to "re-steemcraft-kicks"
+    set {_txuuid} to "kick-%{_uuid}%"
+  else:
+    set {_parentpermlink} to "re-%{_steemname}%-kick-%{_uuid}%"
+    set {_txuuid} to "kick-%{_uuid}%-%getRandomUUID()%"
+
+  set {_comment} to "<table><tr><td><strong>User</strong></td><td><strong>Kicked by</strong></td><td><strong>Reason</strong></td><td><strong>Date</strong></td><tr><td>%{_uuid}%</td><td>%uuid of {_executor}%</td><td>%{_reason}%</td><td>%now%</td></tr></table>"
+  set {_parentauthor} to {_steemname}
+  
+  set {_metadata} to JsonNode()
+  set {_tags} to ArrayNode()
+  loop ...getDefaultAppTags():
+    {_tags}.add(loop-value)
+  {_metadata}.put("tags", {_tags})
+  {_metadata}.put("app", getAppName())
+  {_metadata}.put("format", "markdown")
+  {_metadata}.put("warn", "warned")
+  {_metadata}.put("executed", uuid of {_executor})
+  {_metadata}.put("reason", {_reason})
+  {_metadata}.put("warntime", -1)
+
+  createComment({_txuuid},{_steemname},{_comment},{_parentauthor},{_parentpermlink},getDefaultAppTags(),"Kick",{_metadata}.toString())
+  while getSteemResponse({_txuuid}) is "wait":
+    wait 1 tick
+
+  if getSteemResponse({_txuuid}) is not "done":
+    message "%getChatPrefix()% A error occured: %getSteemResponse({_txuuid})%" to {_executor}

--- a/STEEM.CRAFT/addons/steembans/functions/SteemBansLoadConfig.sk
+++ b/STEEM.CRAFT/addons/steembans/functions/SteemBansLoadConfig.sk
@@ -1,0 +1,19 @@
+#
+# ==============
+# SteemBansLoadConfig.sk
+# ==============
+# SteemBansLoadConfig.sk is part of the STEEM.CRAFT addons.
+# ==============
+
+options:
+  enforcedservers: ["skyroad"]
+  configpath: "plugins/STEEM.CRAFT/SteemBans/config.yml"
+
+#
+# > Function - SteemBansLoadConfig
+# > Load the configuration of SteemBans.
+function SteemBansLoadConfig():
+  loadyamlconfig({@configpath},"steembans")
+  if getyamlconfigobject("steembans","enforcedservers") is not set:
+    setyamlconfigobject("steembans","enforcedservers",{@enforcedservers})
+  saveyamlconfig({@configpath},"steembans")

--- a/STEEM.CRAFT/addons/steembans/functions/SteemBansUnbanPlayer.sk
+++ b/STEEM.CRAFT/addons/steembans/functions/SteemBansUnbanPlayer.sk
@@ -39,7 +39,20 @@ function SteemBansUnbanPlayer(executor:object,bannedplayer:offline player,reason
   set {_comment} to "<table><tr><td><strong>User</strong></td><td><strong>Unbanned by</strong></td><td><strong>Reason</strong></td><td><strong>Date</strong></td><td><strong>Status</strong></td><tr><td>%{_uuid}%</td><td>%uuid of {_executor}%</td><td>%{_reason}%</td><td>%now%</td><td>UNBANNED</td></tr></table>"
   set {_parentauthor} to {_steemname}
   set {_parentpermlink} to "re-steemcraft-bans"
-  createComment({_txuuid},{_steemname},{_comment},{_parentauthor},{_parentpermlink},getDefaultAppTags(),"Ban","{""tags"":[""steemcraft""],""app"":""%getAppName()%"",""format"":""markdown"",""ban"":""unbanned"",""executed"":""%uuid of {_executor}%"",""bantime"":-1}")
+
+  set {_metadata} to JsonNode()
+  set {_tags} to ArrayNode()
+  loop ...getDefaultAppTags():
+    {_tags}.add(loop-value)
+  {_metadata}.put("tags", {_tags})
+  {_metadata}.put("app", getAppName())
+  {_metadata}.put("format", "markdown")
+  {_metadata}.put("ban", "unbanned")
+  {_metadata}.put("executed", uuid of {_executor})
+  {_metadata}.put("reason", {_reason})
+  {_metadata}.put("bantime", -1)
+
+  createComment({_txuuid},{_steemname},{_comment},{_parentauthor},{_parentpermlink},getDefaultAppTags(),"Ban",{_metadata}.toString())
   while getSteemResponse({_txuuid}) is "wait":
     wait 1 tick
 

--- a/STEEM.CRAFT/addons/steembans/functions/SteemBansUnbanPlayer.sk
+++ b/STEEM.CRAFT/addons/steembans/functions/SteemBansUnbanPlayer.sk
@@ -1,0 +1,50 @@
+#
+# ==============
+# SteemBansUnbanPlayer.sk
+# ==============
+# SteemBansUnbanPlayer.sk is part of the STEEM.CRAFT addons.
+# ==============
+
+#
+# > Function - SteemBansUnbanPlayer
+# > Unbans the defined player with the defined reason.
+# > A unban can fail and result in a still banned account,
+# > make sure the transactions doesn't return an error.
+# > Parameters:
+# > <player> The user who bans a player.
+# > <player> The player who should get unbanned.
+# > [<text>] The reason, why the player is unbanned, can be empty.
+function SteemBansUnbanPlayer(executor:object,bannedplayer:offline player,reason:text="-"):
+  message "%getChatPrefix()% Trying to unban %{_bannedplayer}%..." to {_executor}
+  set {_steemname} to getServerAccountName()
+
+  set {_requestid} to getRawSteemContent({_steemname},"re-steemcraft-bans")
+  while CustomSteemRequestResult({_requestid}) is "wait":
+    wait 1 tick
+  set {_parent} to CustomSteemRequestResult({_requestid})
+  if {_parent}.get("result").get("author").textValue() is "":
+    message "%getChatPrefix()% Creating parent..." to {_executor}
+    set {_txuuid} to "bans"
+    set {_comment} to "Bans of the server @%{_steemname}%."
+    set {_parentauthor} to "steem.craft"
+    set {_parentpermlink} to "bans"
+    createComment({_txuuid},{_steemname},{_comment},{_parentauthor},{_parentpermlink},getDefaultAppTags(),"Bans")
+    while getSteemResponse({_txuuid}) is "wait":
+      wait 1 tick
+    message "%getChatPrefix()% Parent creation successful." to {_executor}
+    wait 5 seconds
+
+  set {_uuid} to uuid of {_bannedplayer}
+  set {_txuuid} to "ban-%{_uuid}%"
+  set {_comment} to "<table><tr><td><strong>User</strong></td><td><strong>Unbanned by</strong></td><td><strong>Reason</strong></td><td><strong>Date</strong></td><td><strong>Status</strong></td><tr><td>%{_uuid}%</td><td>%uuid of {_executor}%</td><td>%{_reason}%</td><td>%now%</td><td>UNBANNED</td></tr></table>"
+  set {_parentauthor} to {_steemname}
+  set {_parentpermlink} to "re-steemcraft-bans"
+  createComment({_txuuid},{_steemname},{_comment},{_parentauthor},{_parentpermlink},getDefaultAppTags(),"Ban","{""tags"":[""steemcraft""],""app"":""%getAppName()%"",""format"":""markdown"",""ban"":""unbanned"",""executed"":""%uuid of {_executor}%"",""bantime"":-1}")
+  while getSteemResponse({_txuuid}) is "wait":
+    wait 1 tick
+
+  if getSteemResponse({_txuuid}) is "done":
+    message "%getChatPrefix()% %{_bannedplayer}% has been unbanned." to {_executor}
+    message "%getChatPrefix()% It may take 30 seconds to take effect globally." to {_executor}
+  else:
+    message "%getChatPrefix()% A error occured: %getSteemResponse({_txuuid})%" to {_executor}

--- a/STEEM.CRAFT/addons/steembans/functions/SteemBansWarnPlayer.sk
+++ b/STEEM.CRAFT/addons/steembans/functions/SteemBansWarnPlayer.sk
@@ -1,0 +1,72 @@
+#
+# ==============
+# SteemBansWarnPlayer.sk
+# ==============
+# SteemBansWarnPlayer.sk is part of the STEEM.CRAFT addons.
+# ==============
+
+#
+# > Function - SteemBansWarnPlayer
+# > Warns the player and creates a comment on Steem
+# > which allows everyone to check the warning.
+# > Parameters:
+# > <player> The user who warns a player.
+# > <player> The player who should get warned.
+# > [<text>] The reason, why the player is warned, can be empty.
+function SteemBansWarnPlayer(executor:object,warnedplayer:offline player,reason:text="-"):
+  message "%getChatPrefix()% Trying to warn %{_warnedplayer}%..." to {_executor}
+  set {_steemname} to getServerAccountName()
+
+  set {_requestid} to getRawSteemContent({_steemname},"re-steemcraft-warns")
+  while CustomSteemRequestResult({_requestid}) is "wait":
+    wait 1 tick
+  set {_parent} to CustomSteemRequestResult({_requestid})
+  if {_parent}.get("result").get("author").textValue() is "":
+    message "%getChatPrefix()% Creating parent..." to {_executor}
+    set {_txuuid} to "warns"
+    set {_comment} to "Warns of the server @%{_steemname}%."
+    set {_parentauthor} to "steem.craft"
+    set {_parentpermlink} to "warns"
+    createComment({_txuuid},{_steemname},{_comment},{_parentauthor},{_parentpermlink},getDefaultAppTags(),"Warns")
+    while getSteemResponse({_txuuid}) is "wait":
+      wait 1 tick
+    message "%getChatPrefix()% Parent creation successful." to {_executor}
+    wait 5 seconds
+
+  set {_uuid} to uuid of {_warnedplayer}
+  set {_requestid} to getRawSteemContent({_steemname},"re-%{_steemname}%-warn-%{_uuid}%")
+  while CustomSteemRequestResult({_requestid}) is "wait":
+    wait 1 tick
+  set {_parent} to CustomSteemRequestResult({_requestid})
+  if {_parent}.get("result").get("author").textValue() is "":
+    set {_parentpermlink} to "re-steemcraft-warns"
+    set {_txuuid} to "warn-%{_uuid}%"
+  else:
+    set {_parentpermlink} to "re-%{_steemname}%-warn-%{_uuid}%"
+    set {_txuuid} to "warn-%{_uuid}%-%getRandomUUID()%"
+
+  set {_comment} to "<table><tr><td><strong>User</strong></td><td><strong>Warned by</strong></td><td><strong>Reason</strong></td><td><strong>Date</strong></td><tr><td>%{_uuid}%</td><td>%uuid of {_executor}%</td><td>%{_reason}%</td><td>%now%</td></tr></table>"
+  set {_parentauthor} to {_steemname}
+  
+  set {_metadata} to JsonNode()
+  set {_tags} to ArrayNode()
+  loop ...getDefaultAppTags():
+    {_tags}.add(loop-value)
+  {_metadata}.put("tags", {_tags})
+  {_metadata}.put("app", getAppName())
+  {_metadata}.put("format", "markdown")
+  {_metadata}.put("warn", "warned")
+  {_metadata}.put("executed", uuid of {_executor})
+  {_metadata}.put("reason", {_reason})
+  {_metadata}.put("warntime", -1)
+
+  createComment({_txuuid},{_steemname},{_comment},{_parentauthor},{_parentpermlink},getDefaultAppTags(),"Ban",{_metadata}.toString())
+  while getSteemResponse({_txuuid}) is "wait":
+    wait 1 tick
+
+  if getSteemResponse({_txuuid}) is "done":
+    message "%getChatPrefix()% %{_warnedplayer}% has been warned." to {_executor}
+    if {_warnedplayer} is online:
+      message "%getChatPrefix()% You have been warned: %{_reason}%." to {_warnedplayer}
+  else:
+    message "%getChatPrefix()% A error occured: %getSteemResponse({_txuuid})%" to {_executor}

--- a/STEEM.CRAFT/addons/steembans/readme.md
+++ b/STEEM.CRAFT/addons/steembans/readme.md
@@ -1,0 +1,21 @@
+## Permissions:
+```steembans.ban
+steembans.unban
+steembans.mute
+steembans.unmute
+steembans.warn
+steembans.kick```
+
+## Commands:
+```/steembans reload
+/steembans help
+/ban
+/unban
+/mute
+/unmute
+/warn
+/kick```
+
+## Configurationn files:
+Go to your plugins folder and search for STEEM.CRAFT, there, a SteemBans folder
+is being created after the first startup.

--- a/STEEM.CRAFT/addons/steembans/readme.md
+++ b/STEEM.CRAFT/addons/steembans/readme.md
@@ -1,20 +1,18 @@
 ## Permissions:
 ```steembans.ban
 steembans.unban
-steembans.mute
-steembans.unmute
 steembans.warn
-steembans.kick```
+steembans.kick
+steembans.check```
 
 ## Commands:
 ```/steembans reload
 /steembans help
-/ban
-/unban
-/mute
-/unmute
-/warn
-/kick```
+/steembanns check <player>
+/ban <player> <reason>
+/unban <player> <reason>
+/warn <player> <reason>
+/kick <player> <reason>```
 
 ## Configurationn files:
 Go to your plugins folder and search for STEEM.CRAFT, there, a SteemBans folder


### PR DESCRIPTION
SteemBans allows server operators to ban players and store the ban data to Steem. Other servers can connect together and access the bans of other servers to use them to their advantage, e.g. use the bans of a partnered server.

- [x] Banning & unbanning works
- [x] Banned player's can't join
- [x] Kicking works & gets broadcasted
- [x] Warning works & gets broadcasted
- [x] Fallback is working (simply ban the player)